### PR TITLE
Size, icon, and button tweaks

### DIFF
--- a/src/plugins/discover/public/application/main/components/document_explorer_callout/document_explorer_update_callout.tsx
+++ b/src/plugins/discover/public/application/main/components/document_explorer_callout/document_explorer_update_callout.tsx
@@ -61,7 +61,9 @@ export const DocumentExplorerUpdateCallout = () => {
     <EuiCallOut
       className="dscDocumentExplorerCallout"
       title={<CalloutTitle onCloseCallout={onCloseCallout} />}
-      iconType="search"
+      iconType="tableDensityNormal"
+      heading="h3"
+      size="s"
     >
       <p>
         <FormattedMessage
@@ -94,13 +96,13 @@ export const DocumentExplorerUpdateCallout = () => {
       </p>
       <EuiButton
         data-test-subj="document-explorer-update-callout-dismiss-button"
-        iconType="tableDensityNormal"
+        iconType="check"
         size="s"
         onClick={onCloseCallout}
       >
         <FormattedMessage
           id="discover.docExplorerUpdateCallout.dismissButtonLabel"
-          defaultMessage="Dismiss"
+          defaultMessage="Got it"
         />
       </EuiButton>
     </EuiCallOut>


### PR DESCRIPTION
## Summary

1. Change title icon from magnifying glass to table which was previously in the button; emphasizes table enhancements
2. Change callout size to small as the font sizes better match to surrounding elements (i.e. fonts sizes in the table and field list)
3. Change button text to be more positive/affirming; suspect people would see 'Dismiss' and just click it without reading the callout message

<img width="1451" alt="Screen Shot 2022-04-19 at 12 47 59 PM" src="https://user-images.githubusercontent.com/446285/164065468-a39ae925-b600-47c5-8a81-89d1fad7744c.png">

