### PR TITLE
[Discover][Unified Search][Alerting] Configurable filter menu options

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_bar.tsx
@@ -11,7 +11,7 @@ import { InjectedIntl, injectI18n } from '@kbn/i18n-react';
 import type { Filter } from '@kbn/es-query';
 import React, { useRef } from 'react';
 import { DataView } from '@kbn/data-views-plugin/public';
-import FilterItems from './filter_item/filter_items';
+import FilterItems, { Props as FilterItemsProps } from './filter_item/filter_items';
 
 import { filterBarStyles } from './filter_bar.styles';
 
@@ -22,6 +22,7 @@ export interface Props {
   indexPatterns: DataView[];
   intl: InjectedIntl;
   timeRangeForSuggestionsOverride?: boolean;
+  hiddenPanelOptions?: FilterItemsProps['hiddenPanelOptions'];
   /**
    * Applies extra styles necessary when coupled with the query bar
    */
@@ -48,6 +49,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
         onFiltersUpdated={props.onFiltersUpdated}
         indexPatterns={props.indexPatterns!}
         timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
+        hiddenPanelOptions={props.hiddenPanelOptions}
       />
     </EuiFlexGroup>
   );

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_item.tsx
@@ -29,8 +29,7 @@ import {
 import { FilterEditor } from '../filter_editor';
 import { FilterView } from '../filter_view';
 import { getIndexPatterns } from '../../services';
-
-type PanelOptions = 'pinFilter' | 'editFilter' | 'negateFilter' | 'disableFilter' | 'deleteFilter';
+import { FilterPanelOption } from '../../types';
 
 export interface FilterItemProps {
   id: string;
@@ -41,7 +40,7 @@ export interface FilterItemProps {
   onRemove: () => void;
   intl: InjectedIntl;
   uiSettings: IUiSettingsClient;
-  hiddenPanelOptions?: PanelOptions[];
+  hiddenPanelOptions?: FilterPanelOption[];
   timeRangeForSuggestionsOverride?: boolean;
 }
 
@@ -247,7 +246,7 @@ export function FilterItem(props: FilterItemProps) {
 
     if (hiddenPanelOptions && hiddenPanelOptions.length > 0) {
       mainPanelItems = mainPanelItems.filter(
-        (pItem) => !hiddenPanelOptions.includes(pItem['data-test-subj'] as PanelOptions)
+        (pItem) => !hiddenPanelOptions.includes(pItem['data-test-subj'] as FilterPanelOption)
       );
     }
     return [

--- a/src/plugins/unified_search/public/filter_bar/filter_item/filter_items.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_item/filter_items.tsx
@@ -15,7 +15,7 @@ import { IDataPluginServices } from '@kbn/data-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { DataView } from '@kbn/data-views-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { FilterItem } from './filter_item';
+import { FilterItem, FilterItemProps } from './filter_item';
 
 export interface Props {
   filters: Filter[];
@@ -23,6 +23,7 @@ export interface Props {
   indexPatterns: DataView[];
   intl: InjectedIntl;
   timeRangeForSuggestionsOverride?: boolean;
+  hiddenPanelOptions?: FilterItemProps['hiddenPanelOptions'];
 }
 
 const FilterItemsUI = React.memo(function FilterItemsUI(props: Props) {
@@ -56,6 +57,7 @@ const FilterItemsUI = React.memo(function FilterItemsUI(props: Props) {
           onRemove={() => onRemove(i)}
           indexPatterns={props.indexPatterns}
           uiSettings={uiSettings!}
+          hiddenPanelOptions={props.hiddenPanelOptions}
           timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
         />
       </EuiFlexItem>

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -20,7 +20,7 @@ import { i18n } from '@kbn/i18n';
 import type { Filter, Query } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { TimeRange, SavedQueryService, SavedQuery } from '@kbn/data-plugin/public';
-import { QueryBarMenuPanels } from './query_bar_menu_panels';
+import { QueryBarMenuPanels, QueryBarMenuPanelsProps } from './query_bar_menu_panels';
 import { FilterEditorWrapper } from './filter_editor_wrapper';
 
 export interface QueryBarMenuProps {
@@ -36,6 +36,7 @@ export interface QueryBarMenuProps {
   saveAsNewQueryFormComponent?: JSX.Element;
   saveFormComponent?: JSX.Element;
   manageFilterSetComponent?: JSX.Element;
+  hiddenPanelOptions?: QueryBarMenuPanelsProps['hiddenPanelOptions'];
   onFiltersUpdated?: (filters: Filter[]) => void;
   filters?: Filter[];
   query?: Query;
@@ -60,6 +61,7 @@ export function QueryBarMenu({
   saveAsNewQueryFormComponent,
   saveFormComponent,
   manageFilterSetComponent,
+  hiddenPanelOptions,
   openQueryBarMenu,
   toggleFilterBarMenuPopover,
   onFiltersUpdated,
@@ -124,6 +126,7 @@ export function QueryBarMenu({
     savedQueryService,
     saveAsNewQueryFormComponent,
     manageFilterSetComponent,
+    hiddenPanelOptions,
     nonKqlMode,
     closePopover,
     onQueryBarSubmit,

--- a/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_menu_panels.tsx
@@ -36,8 +36,17 @@ import type {
 } from '@kbn/data-plugin/public';
 import { fromUser } from './from_user';
 import { QueryLanguageSwitcher } from './language_switcher';
+import { FilterPanelOption } from '../types';
 
-interface QueryBarMenuPanelProps {
+const MAP_ITEMS_TO_FILTER_OPTION: Record<string, FilterPanelOption> = {
+  'filter-sets-pinAllFilters': 'pinFilter',
+  'filter-sets-unpinAllFilters': 'pinFilter',
+  'filter-sets-enableAllFilters': 'disableFilter',
+  'filter-sets-disableAllFilters': 'disableFilter',
+  'filter-sets-invertAllFilters': 'negateFilter',
+};
+
+export interface QueryBarMenuPanelsProps {
   filters?: Filter[];
   savedQuery?: SavedQuery;
   language: string;
@@ -50,6 +59,7 @@ interface QueryBarMenuPanelProps {
   savedQueryService: SavedQueryService;
   saveAsNewQueryFormComponent?: JSX.Element;
   manageFilterSetComponent?: JSX.Element;
+  hiddenPanelOptions?: FilterPanelOption[];
   nonKqlMode?: 'lucene' | 'text';
   closePopover: () => void;
   onQueryBarSubmit: (payload: { dateRange: TimeRange; query?: Query }) => void;
@@ -72,6 +82,7 @@ export function QueryBarMenuPanels({
   savedQueryService,
   saveAsNewQueryFormComponent,
   manageFilterSetComponent,
+  hiddenPanelOptions,
   nonKqlMode,
   closePopover,
   onQueryBarSubmit,
@@ -79,7 +90,7 @@ export function QueryBarMenuPanels({
   onClearSavedQuery,
   onQueryChange,
   setRenderedComponent,
-}: QueryBarMenuPanelProps) {
+}: QueryBarMenuPanelsProps) {
   const kibana = useKibana<IDataPluginServices>();
   const { appName, usageCollection, uiSettings, http, storage } = kibana.services;
   const reportUiCounter = usageCollection?.reportUiCounter.bind(usageCollection, appName);
@@ -319,7 +330,7 @@ export function QueryBarMenuPanels({
     });
   }
 
-  const panels = [
+  let panels = [
     {
       id: 0,
       title: (
@@ -489,6 +500,22 @@ export function QueryBarMenuPanels({
       content: <div>{manageFilterSetComponent}</div>,
     },
   ] as EuiContextMenuPanelDescriptor[];
+
+  if (hiddenPanelOptions && hiddenPanelOptions.length > 0) {
+    panels = panels.map((panel) => ({
+      ...panel,
+      items: panel.items?.filter((panelItem) => {
+        if (!panelItem['data-test-subj']) {
+          return true;
+        }
+        const panelFilterOption = MAP_ITEMS_TO_FILTER_OPTION[panelItem['data-test-subj']];
+        if (!panelFilterOption) {
+          return true;
+        }
+        return !hiddenPanelOptions.includes(panelFilterOption);
+      }),
+    }));
+  }
 
   return panels;
 }

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -25,7 +25,7 @@ import { DataView } from '@kbn/data-views-plugin/public';
 
 import { SavedQueryMeta, SaveQueryForm } from '../saved_query_form';
 import { SavedQueryManagementList } from '../saved_query_management';
-import { QueryBarMenu } from '../query_string_input/query_bar_menu';
+import { QueryBarMenu, QueryBarMenuProps } from '../query_string_input/query_bar_menu';
 import type { DataViewPickerProps } from '../dataview_picker';
 import QueryBarTopRow from '../query_string_input/query_bar_top_row';
 import { FilterBar, FilterItems } from '../filter_bar';
@@ -57,6 +57,7 @@ export interface SearchBarOwnProps {
   showDatePicker?: boolean;
   showAutoRefreshOnly?: boolean;
   filters?: Filter[];
+  hiddenFilterPanelOptions?: QueryBarMenuProps['hiddenPanelOptions'];
   // Date picker
   isRefreshPaused?: boolean;
   refreshInterval?: number;
@@ -394,6 +395,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
         openQueryBarMenu={this.state.openQueryBarMenu}
         onFiltersUpdated={this.props.onFiltersUpdated}
         filters={this.props.filters}
+        hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
         query={this.state.query}
         savedQuery={this.props.savedQuery}
         onClearSavedQuery={this.props.onClearSavedQuery}
@@ -423,6 +425,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
           onFiltersUpdated={this.props.onFiltersUpdated}
           indexPatterns={this.props.indexPatterns!}
           timeRangeForSuggestionsOverride={timeRangeForSuggestionsOverride}
+          hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
         />
       ) : (
         <FilterBar
@@ -431,6 +434,7 @@ class SearchBarUI extends Component<SearchBarProps & WithEuiThemeProps, State> {
           onFiltersUpdated={this.props.onFiltersUpdated}
           indexPatterns={this.props.indexPatterns!}
           timeRangeForSuggestionsOverride={timeRangeForSuggestionsOverride}
+          hiddenPanelOptions={this.props.hiddenFilterPanelOptions}
           data-test-subj="unifiedFilterBar"
         />
       );

--- a/src/plugins/unified_search/public/types.ts
+++ b/src/plugins/unified_search/public/types.ts
@@ -54,3 +54,13 @@ export interface UnifiedSearchPublicPluginStart {
    */
   ui: UnifiedSearchPublicPluginStartUi;
 }
+
+/**
+ * Filter options which will be available in menu panels
+ */
+export type FilterPanelOption =
+  | 'pinFilter'
+  | 'editFilter'
+  | 'negateFilter'
+  | 'disableFilter'
+  | 'deleteFilter';

--- a/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
+++ b/x-pack/plugins/stack_alerts/public/alert_types/es_query/expression/search_source_expression_form.tsx
@@ -17,7 +17,7 @@ import {
   ThresholdExpression,
   ValueExpression,
 } from '@kbn/triggers-actions-ui-plugin/public';
-import { SearchBar } from '@kbn/unified-search-plugin/public';
+import { SearchBar, SearchBarProps } from '@kbn/unified-search-plugin/public';
 import { mapAndFlattenFilters, SavedQuery, TimeHistory } from '@kbn/data-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { DataViewOption, EsQueryAlertParams, SearchType } from '../types';
@@ -62,6 +62,8 @@ const withDebounce = debounce((execute: () => void) => execute(), 500, {
   leading: false,
   trailing: true,
 });
+
+const HIDDEN_FILTER_PANEL_OPTIONS: SearchBarProps['hiddenFilterPanelOptions'] = ['pinFilter'];
 
 export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProps) => {
   const { data } = useTriggersAndActionsUiDeps();
@@ -173,6 +175,7 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
         onQueryChange={onChangeQuery}
         savedQuery={savedQuery}
         filters={filters}
+        hiddenFilterPanelOptions={HIDDEN_FILTER_PANEL_OPTIONS}
         onFiltersUpdated={onUpdateFilters}
         onClearSavedQuery={onClearSavedQuery}
         onSavedQueryUpdated={onSavedQueryUpdated}
@@ -182,7 +185,7 @@ export const SearchSourceExpressionForm = (props: SearchSourceExpressionFormProp
         showFilterBar={true}
         showDatePicker={false}
         showAutoRefreshOnly={false}
-        customSubmitButton={<></>}
+        showSubmitButton={false}
         dateRangeFrom={undefined}
         dateRangeTo={undefined}
         timeHistory={timeHistory}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/131813

## Summary

This PR allows to configure which filter options should be hidden from panels. For Alerting we would like to hide pinning functionality.

Default behaviour:
![May-10-2022 16-18-32](https://user-images.githubusercontent.com/1415710/167650964-ff6c8bbd-ac04-4ea0-9cfc-54b5752e8a6e.gif)

"Pinning" is hidden for Alerts in Discover page flyout:
![May-10-2022 16-19-38](https://user-images.githubusercontent.com/1415710/167651033-0b6bdcfb-303e-45c9-86d1-350f1f812215.gif)
